### PR TITLE
Fix: don't add cache size when write failed

### DIFF
--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -346,8 +346,7 @@ func (c *Cache) WriteMulti(values map[string][]Value) error {
 			werr = err
 			addedSize -= uint64(Values(v).Size())
 			c.decreaseSize(uint64(Values(v).Size()))
-		}
-		if newKey {
+		} else if newKey {
 			addedSize += uint64(len(k))
 			c.increaseSize(uint64(len(k)))
 		}


### PR DESCRIPTION
- Closes #23759
### Required checklist
- [ ] Sample config files updated (both `/etc` folder and `NewDemoConfig` methods) (influxdb and plutonium)
- [ ] openapi swagger.yml updated (if modified API) - link openapi PR
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed)

### Description
fix a bug when write cache failed, cache size shouldn't increase. 

### Note for reviewers:
Check the semantic commit type:
 - Feat: a feature with user-visible changes
 - Fix: a bug fix that we might tell a user “upgrade to get this fix for your issue”
 - Chore: version bumps, internal doc (e.g. README) changes, code comment updates, code formatting fixes… must not be user facing (except dependency version changes)
 - Build: build script changes, CI config changes, build tool updates
 - Refactor: non-user-visible refactoring
 - Check the PR title: we should be able to put this as a one-liner in the release notes
